### PR TITLE
test(v2): pass jobNumber and projectSlug to Job mock

### DIFF
--- a/src/test/kotlin/com/github/unhappychoice/circleci/MockCircleCIAPIClientV2.kt
+++ b/src/test/kotlin/com/github/unhappychoice/circleci/MockCircleCIAPIClientV2.kt
@@ -568,7 +568,7 @@ class MockCircleCIAPIClientV2 : CircleCIAPIClientV2 {
 
     override fun getWorkflowJobs(workflowId: String): Observable<JobListResponse> = Observable.just(
         JobListResponse(
-            items = listOf(Job(id = "id", name = "name", type = "type", status = "status", startedAt = "started_at", stoppedAt = "stopped_at", approvalRequestId = "approval_request_id", dependencies = listOf("dependency"))),
+            items = listOf(Job(id = "id", name = "name", type = "type", status = "status", jobNumber = 1, projectSlug = "project_slug", startedAt = "started_at", stoppedAt = "stopped_at", approvalRequestId = "approval_request_id", dependencies = listOf("dependency"))),
             nextPageToken = "next_page_token"
         )
     )


### PR DESCRIPTION
## Summary
- Update the workflow-jobs `Job` mock in `MockCircleCIAPIClientV2` to pass the `jobNumber` and `projectSlug` parameters that were added to the data class in cbea3a5.

## Why
\`compileTestKotlin\` on master started failing after the V2 \`Job\` model gained two required parameters (\`jobNumber\`, \`projectSlug\`) without the mock being updated, so CI has been red since.

## Test plan
- [x] \`./gradlew clean test\` passes locally
- [ ] CI \`test\` job goes green

Closes unhappychoice/oss-issue-opener#89

🤖 Generated with [Claude Code](https://claude.com/claude-code)